### PR TITLE
fix(Codecov access): Add `directory` parameter to Codecov Actions

### DIFF
--- a/.github/workflows/_test-backend.yml
+++ b/.github/workflows/_test-backend.yml
@@ -41,4 +41,5 @@ jobs:
         uses: codecov/codecov-action@v2.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          directory: backend/
           fail_ci_if_error: true


### PR DESCRIPTION
Was updated with a directory path