### PR TITLE
fix(test-db): Create a function to create and drop test DB tables

### DIFF
--- a/backend/app/api/routes/app_settings.py
+++ b/backend/app/api/routes/app_settings.py
@@ -7,7 +7,7 @@ router = APIRouter(
 )
 
 
-@router.get("/app_settings/", status_code=status.HTTP_200_OK)
+@router.get("/app_settings", status_code=status.HTTP_200_OK)
 async def get_app_settings():
     settings = get_settings()
 

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -8,7 +8,7 @@ from app.models.schemas import users as user_schemas
 router = APIRouter(prefix="/users", tags=["User"])
 
 
-@router.post("/create/", response_model=user_schemas.UserInResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/create", response_model=user_schemas.UserInResponse, status_code=status.HTTP_201_CREATED)
 async def create_user(payload: user_schemas.UserInCreate):
     new_user_id = await user_crud.create_user(payload)
 
@@ -42,7 +42,7 @@ async def retrieve_user_by_id(user_id: int):
     return db_user
 
 
-@router.put("/id/{user_id}/", response_model=user_schemas.UserInResponse, status_code=status.HTTP_200_OK)
+@router.put("/id/{user_id}", response_model=user_schemas.UserInResponse, status_code=status.HTTP_200_OK)
 async def update_user(user_id: int, payload: user_schemas.UserInUpdate):
     db_user = await user_crud.get_user_by_id(user_id)
 
@@ -64,7 +64,7 @@ async def update_user(user_id: int, payload: user_schemas.UserInUpdate):
     return updated_db_user
 
 
-@router.delete("/id/{user_id}/", response_model=user_schemas.UserInResponse, status_code=status.HTTP_202_ACCEPTED)
+@router.delete("/id/{user_id}", response_model=user_schemas.UserInResponse, status_code=status.HTTP_202_ACCEPTED)
 async def remove_user(user_id: int):
     db_user = await user_crud.get_user_by_id(user_id)
 

--- a/backend/app/db/events.py
+++ b/backend/app/db/events.py
@@ -4,7 +4,16 @@ from typing import Any, Coroutine
 from app.core.logging import log
 
 # type: ignore
-from app.db.database import DATABASE_URL, database
+from app.db.database import DATABASE_URL, database, engine, metadata
+
+
+def create_db_tables():
+    """
+    A function to create all DB tables.
+    """
+
+    # metadata.drop_all(engine)
+    metadata.create_all(engine)
 
 
 async def startup_app_db_connection() -> Coroutine[Any, Any, None]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,10 +6,7 @@ from app.core.config import get_settings
 from app.core.events import create_start_app_handler, create_stop_app_handler
 from app.core.settings.app_base_settings import EnvTypes
 from app.core.settings.app_settings import AppSettings
-from app.db.database import engine, metadata
-
-# metadata.drop_all(engine)
-metadata.create_all(engine)
+from app.db.events import create_db_tables
 
 
 def initialize_application(settings: AppSettings = get_settings(EnvTypes.DEV)) -> FastAPI:
@@ -39,3 +36,8 @@ def initialize_application(settings: AppSettings = get_settings(EnvTypes.DEV)) -
 
 
 app = initialize_application()
+
+
+if __name__ == "__main__":
+    create_db_tables()
+    app()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,8 @@ def initialize_application(settings: AppSettings = get_settings(EnvTypes.DEV)) -
     and API endpoints for the backend application.
     """
 
+    create_db_tables()
+
     # FastAPI instance initialized with AppSettings attributes
     application = FastAPI(**settings.fastapi_kwargs)
     application.add_middleware(
@@ -36,8 +38,3 @@ def initialize_application(settings: AppSettings = get_settings(EnvTypes.DEV)) -
 
 
 app = initialize_application()
-
-
-if __name__ == "__main__":
-    create_db_tables()
-    app()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,8 @@
 # fmt: off
 # type: ignore
-import databases
+
+from typing import Generator
+
 import pytest
 import sqlalchemy
 from fastapi import FastAPI
@@ -12,40 +14,45 @@ from app.core.settings.app_base_settings import EnvTypes
 
 # Set up the `app_env` to use the TEST environment settings
 settings = get_settings(app_env=EnvTypes.TEST)
-TEST_DATABASE_URL = settings.database_url
-
-# Databases query builder
-test_database = databases.Database(TEST_DATABASE_URL, force_rollback=True)
-
-metadata = sqlalchemy.MetaData()
 
 
 @pytest.fixture(name="test_app")
 def test_app() -> FastAPI:
+    """
+    A fixture that re-initializes the FastAPI instance for test application.
+    """
     from app.main import initialize_application  # type: ignore
 
     return initialize_application(settings=settings)
 
 
-def create_and_drop_test_database():
+def create_and_drop_test_db() -> Generator[None, None, None]:
+    """
+    A function for creating database tables before testing and delete them at the end.
+    """
 
-    # Create test database and DB tables
+    TEST_DATABASE_URL = settings.database_url
+
+    # Databases query builder
+    # test_database = databases.Database(TEST_DATABASE_URL, force_rollback=True)
+
+    test_metadata = sqlalchemy.MetaData()
     test_engine = sqlalchemy.create_engine(
         TEST_DATABASE_URL, connect_args={"check_same_thread": False}, future=True, echo=True
     )
-    metadata.create_all(test_engine)
+    test_metadata.create_all(test_engine)
 
     # Run the test suite
     yield
 
     # Delete all DB tables
-    metadata.drop_all(test_engine)
+    test_metadata.drop_all(test_engine)
 
 
 @pytest.fixture(name="async_client")
 async def async_client(test_app: FastAPI) -> AsyncClient:
 
-    create_and_drop_test_database()
+    create_and_drop_test_db()
 
     # Initialize the test client for endpoint request
     with TestClient(test_app) as client:

--- a/backend/tests/unit_tests/test_api/test_app_settings.py
+++ b/backend/tests/unit_tests/test_api/test_app_settings.py
@@ -2,7 +2,7 @@ async def test_async_retrieve_app_settings_route(async_client):
 
     expected = {"environment": "production"}
 
-    response = async_client.get("/api/app_settings/")
+    response = async_client.get("/api/app_settings")
 
     assert response.status_code == 200
     assert response.json() == expected

--- a/backend/tests/unit_tests/test_api/test_users.py
+++ b/backend/tests/unit_tests/test_api/test_users.py
@@ -37,7 +37,7 @@ async def test_create_users(async_client, monkeypatch):
     monkeypatch.setattr(user_crud, "create_user", mock_create_user)
 
     response = async_client.post(
-        "/api/users/create/",
+        "/api/users/create",
         data=orjson.dumps(test_request_payload),
     )
 
@@ -47,7 +47,7 @@ async def test_create_users(async_client, monkeypatch):
 
 async def test_invalid_create_user(async_client):
 
-    response = async_client.post("/api/users/create/", data=orjson.dumps({}))
+    response = async_client.post("/api/users/create", data=orjson.dumps({}))
 
     assert response.status_code == 422
     assert response.json() == {
@@ -74,7 +74,7 @@ async def test_invalid_create_user(async_client):
         "username": "johndoe",
     }
 
-    response = async_client.post("/api/users/create/", data=orjson.dumps(test_request_payload))
+    response = async_client.post("/api/users/create", data=orjson.dumps(test_request_payload))
     assert response.status_code == 422
     assert response.json()["detail"][0]["msg"] == "field required"
 
@@ -119,7 +119,7 @@ async def test_async_retrieve_all_users(async_client, monkeypatch):
 
     monkeypatch.setattr(user_crud, "get_all_users", mock_get_all_users)
 
-    response = async_client.get("/api/users/")
+    response = async_client.get("/api/users")
 
     assert response.status_code == 200
     assert response.json() == expected_data
@@ -201,7 +201,7 @@ async def test_async_update_user(async_client, monkeypatch):
 
     monkeypatch.setattr(user_crud, "update_user", mock_update_user)
 
-    response = async_client.put("/api/users/id/1/", data=orjson.dumps(expected_updated_data))
+    response = async_client.put("/api/users/id/1", data=orjson.dumps(expected_updated_data))
 
     assert response.status_code == 200
     assert response.json() == expected_updated_data
@@ -256,7 +256,7 @@ async def test_async_remove_user(async_client, monkeypatch):
 
     monkeypatch.setattr(user_crud, "delete_user", mock_delete_user)
 
-    response = async_client.delete("/api/users/id/1/")
+    response = async_client.delete("/api/users/id/1")
 
     assert response.status_code == 202
     assert response.json() == expected_data
@@ -276,6 +276,6 @@ async def test_async_remove_user_by_incorrect_id_data_type(async_client, monkeyp
 
     monkeypatch.setattr(user_crud, "get_user_by_id", mock_get_user_by_id)
 
-    response = async_client.delete("/api/users/id/66G/")
+    response = async_client.delete("/api/users/id/66G")
     assert response.status_code == 422
     assert response.json()["detail"] == expected_data


### PR DESCRIPTION
BUG: The `metadata.drop_all(test_engine)` seems to not work properly, thus the failing `test` job in CI-Backend.

SOLUTION: Pull metadata.create_all() and .drop_all() into 1 function and execute it in the `async_client` fixture at once.