### PR TITLE
feat: Create Publisher and refactor Journalist

### DIFF
--- a/backend/app/api/dependencies/journalists.py
+++ b/backend/app/api/dependencies/journalists.py
@@ -18,7 +18,7 @@ async def get_journalist(
 ) -> Journalist:
 
     try:
-        return await profiles_repo.get_journalist_profile_by_username(
+        return await profiles_repo.create_journalist_profile_from_getting_user_by_username(
             username=username,
             journalist_profile=user,
         )

--- a/backend/app/api/dependencies/publishers.py
+++ b/backend/app/api/dependencies/publishers.py
@@ -1,0 +1,25 @@
+import fastapi
+
+from app.api.dependencies.authorization import retrieve_current_user_auth
+from app.api.dependencies.repository import get_repository
+from app.api.exceptions.http_exc_404 import http404_exc_username_not_found
+from app.db.errors import EntityDoesNotExist
+from app.db.repositories.publishers import PublishersRepository
+from app.models.domain.publishers import Publisher
+from app.models.domain.users import User
+from app.models.schemas.publishers import PublisherInResponse
+
+
+async def retrieve_current_publisher_auth(
+    username: str = fastapi.Path(..., min_length=3),
+    current_user: User = fastapi.Depends(retrieve_current_user_auth()),
+    publishers_repo: PublishersRepository = fastapi.Depends(get_repository(PublishersRepository)),
+) -> Publisher:
+
+    try:
+        db_publisher = await publishers_repo.get_publisher_by_user_id(id=current_user.id_)
+
+        return PublisherInResponse(publisher=Publisher(**db_publisher.dict()))
+
+    except EntityDoesNotExist as value_error:
+        raise await http404_exc_username_not_found(username=username) from value_error

--- a/backend/app/api/endpoints.py
+++ b/backend/app/api/endpoints.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.routes.authentication import router as auth_router
 from app.api.routes.journalists import router as journalists_router
+from app.api.routes.publishers import router as publishers_router
 from app.api.routes.users import router as users_router
 
 router = APIRouter()
@@ -9,3 +10,4 @@ router = APIRouter()
 router.include_router(auth_router)
 router.include_router(users_router)
 router.include_router(journalists_router)
+router.include_router(publishers_router)

--- a/backend/app/api/exceptions/http_exc_403.py
+++ b/backend/app/api/exceptions/http_exc_403.py
@@ -1,10 +1,10 @@
 import fastapi
 
-from app.resources.http_exc_details import HTTP_300_DETAILS
+from app.resources.http_exc_details import HTTP_403_DETAILS
 
 
 async def http403_exc_forbidden() -> Exception:
     raise fastapi.HTTPException(
         status_code=fastapi.status.HTTP_403_FORBIDDEN,
-        detail=HTTP_300_DETAILS,
+        detail=HTTP_403_DETAILS,
     )

--- a/backend/app/api/routes/journalists.py
+++ b/backend/app/api/routes/journalists.py
@@ -1,48 +1,123 @@
+from typing import List
+
 import fastapi
 
 from app.api.dependencies.authorization import retrieve_current_user_auth
-from app.api.dependencies.journalists import get_journalist
+from app.api.dependencies.journalists import retrieve_current_journalist_auth
 from app.api.dependencies.repository import get_repository
+from app.api.exceptions.http_exc_403 import http403_exc_forbidden
 from app.api.exceptions.http_exc_404 import http404_exc_username_not_found
 from app.db.repositories.journalists import JournalistsRepository
 from app.models.domain.journalists import Journalist
 from app.models.domain.users import User
-from app.models.schemas.journalists import JournalistInResponse, JournalistInUpdate
+from app.models.schemas.journalists import JournalistInCreate, JournalistInResponse, JournalistInUpdate
 
 router = fastapi.APIRouter(prefix="/journalists", tags=["journalists"])
 
 
-@router.get("/{username}", response_model=JournalistInResponse, name="journalists:get-journalist-profile")
-async def retrieve_journalist_profile_by_username(
-    journalist_profile: Journalist = fastapi.Depends(get_journalist),
-) -> JournalistInResponse:
-
-    return JournalistInResponse(profile=journalist_profile)
-
-
-@router.put(
-    path="/{username}",
-    name="journalists:update-journalist",
+@router.post(
+    path="",
     response_model=JournalistInResponse,
-    status_code=fastapi.status.HTTP_200_OK,
+    name="journalists:create-journalist-for-user-profile",
+    status_code=fastapi.status.HTTP_201_CREATED,
 )
-async def update_journalist_profile_by_username(
-    username: str,
-    journalist_update: JournalistInUpdate = fastapi.Body(..., embed=True, alias="journalist"),
+async def create_journalist_for_user_profile(
     current_user: User = fastapi.Depends(retrieve_current_user_auth()),
-    current_journalist: User = fastapi.Depends(get_journalist),
+    journalist_create: JournalistInCreate = fastapi.Body(..., embed=True, alias="journalist"),
     journalists_repo: JournalistsRepository = fastapi.Depends(get_repository(JournalistsRepository)),
 ) -> JournalistInResponse:  # type: ignore
 
-    if current_journalist.user_id != current_user.id_:
-        raise await http404_exc_username_not_found(username=username)  # type: ignore
+    if current_user.is_publisher:
+        raise await http403_exc_forbidden()
 
-    updated_journalist = await journalists_repo.update_journalist_profile(
-        journalist=current_journalist, **journalist_update.dict()
+    new_journalist = await journalists_repo.create_journalist_by_username(
+        username=current_user.username, **journalist_create.dict()
     )
 
     return JournalistInResponse(
-        profile=Journalist(
+        journalist=Journalist(
+            first_name=new_journalist.first_name,
+            last_name=new_journalist.last_name,
+            profile_picture=new_journalist.profile_picture,
+            banner=new_journalist.banner,
+            bio=new_journalist.bio,
+            address=new_journalist.address,
+            postal_code=new_journalist.postal_code,
+            state=new_journalist.state,
+            country=new_journalist.country,
+            office_phone_number=new_journalist.office_phone_number,
+            mobile_phone_number=new_journalist.mobile_phone_number,
+            user_id=current_user.id_,
+        )
+    )
+
+
+@router.get(path="", name="journalists:retrieve-all-journalists", response_model=List[JournalistInResponse])
+async def retrieve_all_journalists(
+    journalists_repo: JournalistsRepository = fastapi.Depends(get_repository(JournalistsRepository)),
+) -> List[JournalistInResponse]:
+
+    db_journalists = await journalists_repo.get_journalists()
+    db_journalists_list = []
+
+    for journalist in db_journalists:
+        journalist = JournalistInResponse(
+            journalist=Journalist(
+                first_name=journalist.first_name,
+                last_name=journalist.last_name,
+                profile_picture=journalist.profile_picture,
+                banner=journalist.banner,
+                bio=journalist.bio,
+                address=journalist.address,
+                postal_code=journalist.postal_code,
+                state=journalist.state,
+                country=journalist.country,
+                office_phone_number=journalist.office_phone_number,
+                mobile_phone_number=journalist.mobile_phone_number,
+                user_id=journalist.user_id,
+            )
+        )
+        db_journalists_list.append(journalist)
+
+    return db_journalists_list
+
+
+@router.get(
+    path="/journalist/{username}",
+    response_model=JournalistInResponse,
+    name="journalists:retrieve-current-journalist",
+    status_code=fastapi.status.HTTP_200_OK,
+)
+async def retrieve_current_journalist(
+    current_journalist: Journalist = fastapi.Depends(retrieve_current_journalist_auth),
+) -> JournalistInResponse:  # type: ignore
+
+    return JournalistInResponse(journalist=current_journalist.journalist)
+
+
+@router.put(
+    path="/journalist/{username}",
+    name="journalists:update-current-journalist",
+    response_model=JournalistInResponse,
+    status_code=fastapi.status.HTTP_200_OK,
+)
+async def update_current_journalist(
+    username: str,
+    current_user: User = fastapi.Depends(retrieve_current_user_auth()),
+    current_journalist: Journalist = fastapi.Depends(retrieve_current_journalist_auth),
+    journalist_update: JournalistInUpdate = fastapi.Body(..., embed=True, alias="journalist"),
+    journalists_repo: JournalistsRepository = fastapi.Depends(get_repository(JournalistsRepository)),
+) -> JournalistInResponse:  # type: ignore
+
+    if current_journalist.journalist.user_id != current_user.id_:
+        raise await http404_exc_username_not_found(username=username)  # type: ignore
+
+    updated_journalist = await journalists_repo.update_journalist_by_user_id(
+        user_id=current_journalist.journalist.user_id, **journalist_update.dict()
+    )
+
+    return JournalistInResponse(
+        journalist=Journalist(
             first_name=updated_journalist.first_name,
             last_name=updated_journalist.last_name,
             profile_picture=updated_journalist.profile_picture,

--- a/backend/app/api/routes/journalists.py
+++ b/backend/app/api/routes/journalists.py
@@ -37,7 +37,7 @@ async def update_journalist_profile_by_username(
     if current_journalist.user_id != current_user.id_:
         raise await http404_exc_username_not_found(username=username)  # type: ignore
 
-    updated_journalist = await journalists_repo.update_journalist(
+    updated_journalist = await journalists_repo.update_journalist_profile(
         journalist=current_journalist, **journalist_update.dict()
     )
 
@@ -47,6 +47,12 @@ async def update_journalist_profile_by_username(
             last_name=updated_journalist.last_name,
             profile_picture=updated_journalist.profile_picture,
             bio=updated_journalist.bio,
+            address=updated_journalist.address,
+            postal_code=updated_journalist.postal_code,
+            state=updated_journalist.state,
+            country=updated_journalist.country,
+            office_phone_number=updated_journalist.office_phone_number,
+            mobile_phone_number=updated_journalist.mobile_phone_number,
             user_id=updated_journalist.user_id,
         )
     )

--- a/backend/app/api/routes/publishers.py
+++ b/backend/app/api/routes/publishers.py
@@ -1,0 +1,130 @@
+from typing import List
+
+import fastapi
+
+from app.api.dependencies.authorization import retrieve_current_user_auth
+from app.api.dependencies.publishers import retrieve_current_publisher_auth
+from app.api.dependencies.repository import get_repository
+from app.api.exceptions.http_exc_403 import http403_exc_forbidden
+from app.api.exceptions.http_exc_404 import http404_exc_username_not_found
+from app.db.repositories.publishers import PublishersRepository
+from app.models.domain.publishers import Publisher
+from app.models.domain.users import User
+from app.models.schemas.publishers import PublisherInCreate, PublisherInResponse, PublisherInUpdate
+
+router = fastapi.APIRouter(prefix="/publishers", tags=["publishers"])
+
+
+@router.post(
+    path="",
+    response_model=PublisherInResponse,
+    name="publishers:create-publisher-for-user-profile",
+    status_code=fastapi.status.HTTP_201_CREATED,
+)
+async def create_publisher_for_user_profile(
+    current_user: User = fastapi.Depends(retrieve_current_user_auth()),
+    publisher_create: PublisherInCreate = fastapi.Body(..., embed=True, alias="publisher"),
+    publishers_repo: PublishersRepository = fastapi.Depends(get_repository(PublishersRepository)),
+) -> Publisher:
+
+    if not current_user.is_publisher:
+        raise await http403_exc_forbidden()
+
+    new_publisher = await publishers_repo.create_publisher_by_username(
+        username=current_user.username, **publisher_create.dict()
+    )
+
+    return PublisherInResponse(
+        publisher=Publisher(
+            name=new_publisher.name,
+            profile_picture=new_publisher.profile_picture,
+            banner=new_publisher.banner,
+            bio=new_publisher.bio,
+            address=new_publisher.address,
+            postal_code=new_publisher.postal_code,
+            state=new_publisher.state,
+            country=new_publisher.country,
+            office_phone_number=new_publisher.office_phone_number,
+            mobile_phone_number=new_publisher.mobile_phone_number,
+            user_id=current_user.id_,
+        )
+    )
+
+
+@router.get(path="", name="publishers:retrieve-all-publishers", response_model=List[PublisherInResponse])
+async def retrieve_all_publishers(
+    publishers_repo: PublishersRepository = fastapi.Depends(get_repository(PublishersRepository)),
+) -> List[PublisherInResponse]:
+
+    db_publishers = await publishers_repo.get_publishers()
+    db_publishers_list = []
+
+    for publisher in db_publishers:
+        publisher = PublisherInResponse(
+            publisher=Publisher(
+                name=publisher.name,
+                profile_picture=publisher.profile_picture,
+                banner=publisher.banner,
+                bio=publisher.bio,
+                address=publisher.address,
+                postal_code=publisher.postal_code,
+                state=publisher.state,
+                country=publisher.country,
+                office_phone_number=publisher.office_phone_number,
+                mobile_phone_number=publisher.mobile_phone_number,
+                user_id=publisher.user_id,
+            )
+        )
+        db_publishers_list.append(publisher)
+
+    return db_publishers_list
+
+
+@router.get(
+    path="/publisher/{username}",
+    response_model=PublisherInResponse,
+    name="publishers:retrieve-current-publisher",
+    status_code=fastapi.status.HTTP_200_OK,
+)
+async def retrieve_current_publisher(
+    current_publisher: Publisher = fastapi.Depends(retrieve_current_publisher_auth),
+) -> PublisherInResponse:
+
+    return PublisherInResponse(publisher=current_publisher.publisher)
+
+
+@router.put(
+    path="/publisher/{username}",
+    name="publishers:update-current-publisher",
+    response_model=PublisherInResponse,
+    status_code=fastapi.status.HTTP_200_OK,
+)
+async def update_current_publisher(
+    username: str,
+    current_user: User = fastapi.Depends(retrieve_current_user_auth()),
+    current_publisher: Publisher = fastapi.Depends(retrieve_current_publisher_auth),
+    publisher_update: PublisherInUpdate = fastapi.Body(..., embed=True, alias="publisher"),
+    publishers_repo: PublishersRepository = fastapi.Depends(get_repository(PublishersRepository)),
+) -> PublisherInResponse:  # type: ignore
+
+    if current_publisher.publisher.user_id != current_user.id_:
+        raise await http404_exc_username_not_found(username=username)  # type: ignore
+
+    updated_publisher = await publishers_repo.update_publisher_by_user_id(
+        user_id=current_publisher.publisher.user_id, **publisher_update.dict()
+    )
+
+    return PublisherInResponse(
+        publisher=Publisher(
+            name=updated_publisher.name,
+            profile_picture=updated_publisher.profile_picture,
+            bio=updated_publisher.bio,
+            address=updated_publisher.address,
+            postal_code=updated_publisher.postal_code,
+            state=updated_publisher.state,
+            country=updated_publisher.country,
+            office_phone_number=updated_publisher.office_phone_number,
+            mobile_phone_number=updated_publisher.mobile_phone_number,
+            user_id=updated_publisher.user_id,
+        )
+    )

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -18,18 +18,18 @@ router = fastapi.APIRouter(prefix="/users", tags=["users"])
 settings = get_settings()
 
 
-@router.get(path="", name="users:get-all-users", response_model=List[UserInResponse])
+@router.get(path="", name="users:retrieve-all-users", response_model=List[UserInResponse])
 async def retrieve_all_users(
     users_repo: UsersRepository = fastapi.Depends(get_repository(UsersRepository)),
 ) -> List[UserInResponse]:
 
-    users_in_db = await users_repo.get_users()
-    users_with_token = []
+    db_users = await users_repo.get_users()
+    db_users_list = []
 
-    for user in users_in_db:
+    for user in db_users:
         token = generate_access_token(
-            user,
-            settings.secret_key,
+            user=user,
+            secret_key=settings.secret_key,
         )
         user = UserInResponse(
             user=UserWithToken(
@@ -41,14 +41,14 @@ async def retrieve_all_users(
                 token=token,
             ),
         )
-        users_with_token.append(user)
+        db_users_list.append(user)
 
-    return users_with_token
+    return db_users_list
 
 
 @router.get(
     path="/user/{id}",
-    name="users:get-current-user",
+    name="users:retrieve-current-user",
     response_model=UserInResponse,
     status_code=fastapi.status.HTTP_200_OK,
 )
@@ -62,8 +62,8 @@ async def retrieve_current_user(
         return await http404_exc_id_not_found(id=id)
 
     token = generate_access_token(
-        current_user,
-        settings.secret_key,
+        user=current_user,
+        secret_key=settings.secret_key,
     )
 
     return UserInResponse(
@@ -104,8 +104,8 @@ async def update_current_user(
     updated_user = await users_repo.update_user(user=current_user, **user_update.dict())
 
     token = generate_access_token(
-        updated_user,
-        settings.secret_key,
+        user=updated_user,
+        secret_key=settings.secret_key,
     )
 
     return UserInResponse(

--- a/backend/app/db/migrations/versions/a177683deb81_create_tables.py
+++ b/backend/app/db/migrations/versions/a177683deb81_create_tables.py
@@ -80,8 +80,15 @@ def create_journalists_table() -> None:
         sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("first_name", sa.VARCHAR, nullable=True),
         sa.Column("last_name", sa.VARCHAR, nullable=True),
-        sa.Column("bio", sa.VARCHAR, nullable=False),
+        sa.Column("bio", sa.VARCHAR, nullable=True),
         sa.Column("profile_picture", sa.VARCHAR, nullable=True),
+        sa.Column("banner", sa.VARCHAR, nullable=True),
+        sa.Column("address", sa.VARCHAR, nullable=True),
+        sa.Column("postal_code", sa.VARCHAR, nullable=True),
+        sa.Column("state", sa.VARCHAR, nullable=True),
+        sa.Column("country", sa.VARCHAR, nullable=True),
+        sa.Column("office_phone_number", sa.VARCHAR, nullable=True),
+        sa.Column("mobile_phone_number", sa.VARCHAR, nullable=True),
         sa.Column("user_id", sa.BigInteger, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
         *timestamps(),
     )
@@ -90,6 +97,34 @@ def create_journalists_table() -> None:
         CREATE TRIGGER update_journalist_modtime
             BEFORE UPDATE
             ON journalists
+            FOR EACH ROW
+        EXECUTE PROCEDURE update_updated_at_column();
+        """
+    )
+
+
+def create_publishers_table() -> None:
+    op.create_table(
+        "publishers",
+        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("name", sa.VARCHAR, nullable=True),
+        sa.Column("bio", sa.VARCHAR, nullable=True),
+        sa.Column("profile_picture", sa.VARCHAR, nullable=True),
+        sa.Column("banner", sa.VARCHAR, nullable=True),
+        sa.Column("address", sa.VARCHAR, nullable=True),
+        sa.Column("postal_code", sa.VARCHAR, nullable=True),
+        sa.Column("state", sa.VARCHAR, nullable=True),
+        sa.Column("country", sa.VARCHAR, nullable=True),
+        sa.Column("office_phone_number", sa.VARCHAR, nullable=True),
+        sa.Column("mobile_phone_number", sa.VARCHAR, nullable=True),
+        sa.Column("user_id", sa.BigInteger, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        *timestamps(),
+    )
+    op.execute(
+        """
+        CREATE TRIGGER update_publisher_modtime
+            BEFORE UPDATE
+            ON publishers
             FOR EACH ROW
         EXECUTE PROCEDURE update_updated_at_column();
         """
@@ -166,6 +201,7 @@ def upgrade() -> None:
     create_updated_at_trigger()
     create_users_table()
     create_journalists_table()
+    create_publishers_table()
     create_articles_table()
     create_images_table()
     create_videos_table()
@@ -175,5 +211,7 @@ def downgrade() -> None:
     op.drop_table("videos")
     op.drop_table("images")
     op.drop_table("articles")
+    op.drop_table("publishers")
+    op.drop_table("journalists")
     op.drop_table("users")
     op.execute("DROP FUNCTION update_updated_at_column")

--- a/backend/app/db/queries/sql/journalists.sql
+++ b/backend/app/db/queries/sql/journalists.sql
@@ -5,6 +5,23 @@ RETURNING
     id, created_at, updated_at;
 
 
+-- name: read-journalists
+SELECT  id,
+        first_name,
+        last_name,
+        profile_picture,
+        banner,
+        bio,
+        address,
+        postal_code,
+        state,
+        country,
+        office_phone_number,
+        mobile_phone_number,
+        user_id
+FROM journalists;
+
+
 -- name: read-journalist-by-user-id^
 SELECT  id,
         first_name,

--- a/backend/app/db/queries/sql/journalists.sql
+++ b/backend/app/db/queries/sql/journalists.sql
@@ -1,6 +1,6 @@
 -- name: create-new-journalist<!
-INSERT INTO journalists (first_name, last_name, profile_picture, bio, user_id)
-VALUES (:first_name, :last_name, :profile_picture, :bio, :user_id)
+INSERT INTO journalists (first_name, last_name, profile_picture, banner, bio, address, postal_code, state, country, office_phone_number, mobile_phone_number, user_id)
+VALUES (:first_name, :last_name, :profile_picture, :banner, :bio, :address, :postal_code, :state, :country, :office_phone_number, :mobile_phone_number, :user_id)
 RETURNING
     id, created_at, updated_at;
 
@@ -10,7 +10,14 @@ SELECT  id,
         first_name,
         last_name,
         profile_picture,
+        banner,
         bio,
+        address,
+        postal_code,
+        state,
+        country,
+        office_phone_number,
+        mobile_phone_number,
         user_id,
         created_at,
         updated_at
@@ -25,7 +32,14 @@ UPDATE
 SET first_name      = :new_first_name,
     last_name       = :new_last_name,
     profile_picture = :new_profile_picture,
-    bio             = :new_bio
+    banner          = :new_banner,
+    bio             = :new_bio,
+    address         = :new_address,
+    postal_code     = :new_postal_code,
+    state           = :new_state,
+    country         = :new_country,
+    office_phone_number = :new_office_phone_number,
+    mobile_phone_number = :new_mobile_phone_number
 WHERE id = :id
 RETURNING
     updated_at;

--- a/backend/app/db/queries/sql/publishers.sql
+++ b/backend/app/db/queries/sql/publishers.sql
@@ -1,14 +1,13 @@
--- name: create-new-journalist<!
-INSERT INTO journalists (first_name, last_name, profile_picture, banner, bio, address, postal_code, state, country, office_phone_number, mobile_phone_number, user_id)
-VALUES (:first_name, :last_name, :profile_picture, :banner, :bio, :address, :postal_code, :state, :country, :office_phone_number, :mobile_phone_number, :user_id)
+-- name: create-new-publisher<!
+INSERT INTO publishers (name, profile_picture, banner, bio, address, postal_code, state, country, office_phone_number, mobile_phone_number, user_id)
+VALUES (:name, :profile_picture, :banner, :bio, :address, :postal_code, :state, :country, :office_phone_number, :mobile_phone_number, :user_id)
 RETURNING
     id, created_at, updated_at;
 
 
--- name: read-journalist-by-user-id^
+-- name: read-publisher-by-user-id^
 SELECT  id,
-        first_name,
-        last_name,
+        name,
         profile_picture,
         banner,
         bio,
@@ -21,16 +20,15 @@ SELECT  id,
         user_id,
         created_at,
         updated_at
-FROM journalists
+FROM publishers
 WHERE user_id = :user_id
 LIMIT 1;
 
 
--- name: update-journalist-by-id<!
+-- name: update-publisher-by-id<!
 UPDATE
     journalists
-SET first_name          = :new_first_name,
-    last_name           = :new_last_name,
+SET name                = :new_name,
     profile_picture     = :new_profile_picture,
     banner              = :new_banner,
     bio                 = :new_bio,

--- a/backend/app/db/queries/sql/publishers.sql
+++ b/backend/app/db/queries/sql/publishers.sql
@@ -5,6 +5,22 @@ RETURNING
     id, created_at, updated_at;
 
 
+-- name: read-publishers
+SELECT  id,
+        name,
+        profile_picture,
+        banner,
+        bio,
+        address,
+        postal_code,
+        state,
+        country,
+        office_phone_number,
+        mobile_phone_number,
+        user_id
+FROM publishers;
+
+
 -- name: read-publisher-by-user-id^
 SELECT  id,
         name,
@@ -27,7 +43,7 @@ LIMIT 1;
 
 -- name: update-publisher-by-id<!
 UPDATE
-    journalists
+    publishers
 SET name                = :new_name,
     profile_picture     = :new_profile_picture,
     banner              = :new_banner,

--- a/backend/app/db/repositories/journalists.py
+++ b/backend/app/db/repositories/journalists.py
@@ -18,29 +18,43 @@ class JournalistsRepository(BaseRepository):
         super().__init__(conn)
         self._users_repo = UsersRepository(conn)
 
-    async def get_journalist_profile_by_username(
+    async def create_journalist_profile_from_getting_user_by_username(
         self,
         *,
         username: str,
         first_name: str = "",
         last_name: str = "",
         profile_picture: str = "",
+        banner: str = "",
         bio: str = "",
+        address: str = "",
+        postal_code: str = "",
+        state: str = "",
+        country: str = "",
+        office_phone_number: str = "",
+        mobile_phone_number: str = "",
         journalist_profile: Optional[JournalistProfile],
     ) -> JournalistProfile:
 
         db_user = await self._users_repo.get_user_by_username(username=username)
 
         try:
-            db_journalist = await self.get_journalist_by_id(id=db_user.id_)
+            journalist_profile = await self.get_journalist_by_id(id=db_user.id_)
 
         except EntityDoesNotExist:
 
-            db_journalist = JournalistInDB(
+            journalist_profile = JournalistInDB(
                 first_name=first_name,
                 last_name=last_name,
                 profile_picture=profile_picture,
+                banner=banner,
                 bio=bio,
+                address=address,
+                postal_code=postal_code,
+                state=state,
+                country=country,
+                office_phone_number=office_phone_number,
+                mobile_phone_number=mobile_phone_number,
                 user_id=db_user.id_,
             )
 
@@ -48,41 +62,47 @@ class JournalistsRepository(BaseRepository):
 
                 await queries.create_new_journalist(
                     self.connection,
-                    first_name=db_journalist.first_name,
-                    last_name=db_journalist.last_name,
-                    profile_picture=db_journalist.profile_picture,
-                    bio=db_journalist.bio,
-                    user_id=db_journalist.user_id,
+                    first_name=journalist_profile.first_name,
+                    last_name=journalist_profile.last_name,
+                    profile_picture=journalist_profile.profile_picture,
+                    banner=journalist_profile.banner,
+                    bio=journalist_profile.bio,
+                    address=journalist_profile.address,
+                    postal_code=journalist_profile.postal_code,
+                    state=journalist_profile.state,
+                    country=journalist_profile.country,
+                    office_phone_number=journalist_profile.office_phone_number,
+                    mobile_phone_number=journalist_profile.mobile_phone_number,
+                    user_id=journalist_profile.user_id,
                 )
-
-        journalist_profile = Journalist(
-            first_name=db_journalist.first_name,
-            last_name=db_journalist.last_name,
-            profile_picture=db_journalist.profile_picture,
-            bio=db_journalist.bio,
-            user_id=db_journalist.user_id,
-        )
 
         return journalist_profile
 
     async def get_journalist_by_id(self, *, id: int) -> JournalistInDB:
 
         db_journalist = await queries.read_journalist_by_user_id(self.connection, user_id=id)
-        print(db_journalist)
+
         if db_journalist:
 
             return JournalistInDB(**db_journalist)
 
         raise EntityDoesNotExist(f"User with id {id} does not exist!")
 
-    async def update_journalist(
+    async def update_journalist_profile(
         self,
         *,
         journalist: Journalist,
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
         profile_picture: Optional[str] = None,
+        banner: Optional[str] = None,
         bio: Optional[str] = None,
+        address: Optional[str] = None,
+        postal_code: Optional[str] = None,
+        state: Optional[str] = None,
+        country: Optional[str] = None,
+        office_phone_number: Optional[str] = None,
+        mobile_phone_number: Optional[str] = None,
     ) -> JournalistInDB:
 
         db_journalist = await self.get_journalist_by_id(id=journalist.user_id)
@@ -91,7 +111,14 @@ class JournalistsRepository(BaseRepository):
             db_journalist.first_name = first_name or db_journalist.first_name
             db_journalist.last_name = last_name or db_journalist.last_name
             db_journalist.profile_picture = profile_picture or db_journalist.profile_picture
+            db_journalist.banner = banner or db_journalist.banner
             db_journalist.bio = bio or db_journalist.bio
+            db_journalist.address = address or db_journalist.address
+            db_journalist.postal_code = postal_code or db_journalist.postal_code
+            db_journalist.state = state or db_journalist.state
+            db_journalist.country = country or db_journalist.country
+            db_journalist.office_phone_number = office_phone_number or db_journalist.office_phone_number
+            db_journalist.mobile_phone_number = mobile_phone_number or db_journalist.mobile_phone_number
 
             async with self.connection.transaction():
                 db_journalist.updated_at = await queries.update_journalist_by_id(
@@ -100,7 +127,14 @@ class JournalistsRepository(BaseRepository):
                     new_first_name=db_journalist.first_name,
                     new_last_name=db_journalist.last_name,
                     new_profile_picture=db_journalist.profile_picture,
+                    new_banner=db_journalist.banner,
                     new_bio=db_journalist.bio,
+                    new_address=db_journalist.address,
+                    new_postal_code=db_journalist.postal_code,
+                    new_state=db_journalist.state,
+                    new_country=db_journalist.country,
+                    new_office_phone_number=db_journalist.office_phone_number,
+                    new_mobile_phone_number=db_journalist.mobile_phone_number,
                 )
 
             return db_journalist

--- a/backend/app/db/repositories/publishers.py
+++ b/backend/app/db/repositories/publishers.py
@@ -1,0 +1,146 @@
+# type: ignore
+from typing import List, Optional, Union
+
+from asyncpg import connection as asyncpg_conn
+
+from app.db.errors import EntityDoesNotExist
+from app.db.queries.queries import queries
+from app.db.repositories.base import BaseRepository
+from app.db.repositories.users import UsersRepository
+from app.models.domain.publishers import Publisher, PublisherInDB
+from app.models.domain.users import User
+
+PublisherProfile = Union[User, Publisher]
+
+
+class PublishersRepository(BaseRepository):
+    def __init__(self, conn: asyncpg_conn.Connection):
+        super().__init__(conn)
+        self._users_repo = UsersRepository(conn)
+
+    async def create_publisher_by_username(
+        self,
+        *,
+        username: str,
+        name: str = "",
+        profile_picture: str = "",
+        banner: str = "",
+        bio: str = "",
+        address: str = "",
+        postal_code: str = "",
+        state: str = "",
+        country: str = "",
+        office_phone_number: str = "",
+        mobile_phone_number: str = "",
+    ) -> PublisherProfile:
+
+        db_user = await self._users_repo.get_user_by_username(username=username)
+
+        try:
+            db_publisher = await self.get_publisher_by_user_id(id=db_user.id_)
+
+        except EntityDoesNotExist:
+
+            db_publisher = PublisherInDB(
+                name=name,
+                profile_picture=profile_picture,
+                banner=banner,
+                bio=bio,
+                address=address,
+                postal_code=postal_code,
+                state=state,
+                country=country,
+                office_phone_number=office_phone_number,
+                mobile_phone_number=mobile_phone_number,
+                user_id=db_user.id_,
+            )
+
+            async with self.connection.transaction():
+
+                await queries.create_new_publisher(
+                    self.connection,
+                    name=db_publisher.name,
+                    profile_picture=db_publisher.profile_picture,
+                    banner=db_publisher.banner,
+                    bio=db_publisher.bio,
+                    address=db_publisher.address,
+                    postal_code=db_publisher.postal_code,
+                    state=db_publisher.state,
+                    country=db_publisher.country,
+                    office_phone_number=db_publisher.office_phone_number,
+                    mobile_phone_number=db_publisher.mobile_phone_number,
+                    user_id=db_publisher.user_id,
+                )
+
+        return db_publisher
+
+    async def get_publishers(self) -> List[PublisherInDB]:
+        async with self.connection.transaction():
+            db_publishers = await queries.read_publishers(self.connection)
+            db_publishers_list = []
+
+            for db_publisher in db_publishers:
+
+                db_publishers_list.append(PublisherInDB(**db_publisher))
+
+            return db_publishers_list
+
+    async def get_publisher_by_user_id(self, *, id: int) -> PublisherInDB:
+
+        db_publisher = await queries.read_publisher_by_user_id(self.connection, user_id=id)
+
+        if db_publisher:
+
+            return PublisherInDB(**db_publisher)
+
+        raise EntityDoesNotExist(f"Publisher with id {id} doesn't exist!")
+
+    async def update_publisher_by_user_id(
+        self,
+        *,
+        user_id: int,
+        name: Optional[str] = None,
+        profile_picture: Optional[str] = None,
+        banner: Optional[str] = None,
+        bio: Optional[str] = None,
+        address: Optional[str] = None,
+        postal_code: Optional[str] = None,
+        state: Optional[str] = None,
+        country: Optional[str] = None,
+        office_phone_number: Optional[str] = None,
+        mobile_phone_number: Optional[str] = None,
+    ) -> PublisherInDB:
+
+        db_publisher = await self.get_publisher_by_user_id(id=user_id)
+
+        if db_publisher:
+            db_publisher.name = name or db_publisher.name
+            db_publisher.profile_picture = profile_picture or db_publisher.profile_picture
+            db_publisher.banner = banner or db_publisher.banner
+            db_publisher.bio = bio or db_publisher.bio
+            db_publisher.address = address or db_publisher.address
+            db_publisher.postal_code = postal_code or db_publisher.postal_code
+            db_publisher.state = state or db_publisher.state
+            db_publisher.country = country or db_publisher.country
+            db_publisher.office_phone_number = office_phone_number or db_publisher.office_phone_number
+            db_publisher.mobile_phone_number = mobile_phone_number or db_publisher.mobile_phone_number
+
+            async with self.connection.transaction():
+                db_publisher.updated_at = await queries.update_publisher_by_id(
+                    self.connection,
+                    id=user_id,
+                    new_name=db_publisher.name,
+                    new_profile_picture=db_publisher.profile_picture,
+                    new_banner=db_publisher.banner,
+                    new_bio=db_publisher.bio,
+                    new_address=db_publisher.address,
+                    new_postal_code=db_publisher.postal_code,
+                    new_state=db_publisher.state,
+                    new_country=db_publisher.country,
+                    new_office_phone_number=db_publisher.office_phone_number,
+                    new_mobile_phone_number=db_publisher.mobile_phone_number,
+                )
+
+            return db_publisher
+
+        raise EntityDoesNotExist("Publisher with that ID does not exist!")

--- a/backend/app/models/domain/journalists.py
+++ b/backend/app/models/domain/journalists.py
@@ -10,7 +10,14 @@ class Journalist(IWBaseModel):
     first_name: str = ""
     last_name: str = ""
     profile_picture: Optional[str]
+    banner: Optional[str]
     bio: str = ""
+    address: str = ""
+    postal_code: str = ""
+    state: str = ""
+    country: str = ""
+    office_phone_number: str = ""
+    mobile_phone_number: str = ""
 
     user_id: int
     # wallet_addresses: List[WalletAddress] = []

--- a/backend/app/models/domain/publishers.py
+++ b/backend/app/models/domain/publishers.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from app.models.domain.base import IWBaseModel
+from app.models.mixins.date_time import DateTimeModelMixin
+from app.models.mixins.identifier import IDModelMixin
+
+
+class Publisher(IWBaseModel):
+
+    name: str = ""
+    profile_picture: Optional[str]
+    banner: Optional[str]
+    bio: str = ""
+    address: str = ""
+    postal_code: str = ""
+    state: str = ""
+    country: str = ""
+    office_phone_number: str = ""
+    mobile_phone_number: str = ""
+
+    user_id: int
+    # wallet_addresses: List[WalletAddress] = []
+    # url_addresses: List[URLAdresses] = []
+    # articles: List[Article] = []
+
+
+class PublisherInDB(IDModelMixin, DateTimeModelMixin, Publisher):
+    pass

--- a/backend/app/models/schemas/journalists.py
+++ b/backend/app/models/schemas/journalists.py
@@ -6,8 +6,18 @@ from app.models.domain.journalists import Journalist
 from app.models.schemas.base import IWBaseSchema  # type: ignore
 
 
-class JournalistInResponse(IWBaseSchema):  # type: ignore
-    profile: Journalist
+class JournalistInCreate(IWBaseSchema):
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    profile_picture: Optional[str] = None
+    banner: Optional[str] = None
+    bio: Optional[str] = None
+    address: Optional[str] = None
+    postal_code: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    office_phone_number: Optional[str] = None
+    mobile_phone_number: Optional[str] = None
 
 
 class JournalistInUpdate(pydantic.BaseModel):
@@ -23,3 +33,7 @@ class JournalistInUpdate(pydantic.BaseModel):
     country: Optional[str] = None
     office_phone_number: Optional[str] = None
     mobile_phone_number: Optional[str] = None
+
+
+class JournalistInResponse(IWBaseSchema):  # type: ignore
+    journalist: Journalist

--- a/backend/app/models/schemas/journalists.py
+++ b/backend/app/models/schemas/journalists.py
@@ -15,4 +15,11 @@ class JournalistInUpdate(pydantic.BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     profile_picture: Optional[str] = None
+    banner: Optional[str] = None
     bio: Optional[str] = None
+    address: Optional[str] = None
+    postal_code: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    office_phone_number: Optional[str] = None
+    mobile_phone_number: Optional[str] = None

--- a/backend/app/models/schemas/publishers.py
+++ b/backend/app/models/schemas/publishers.py
@@ -6,8 +6,17 @@ from app.models.domain.publishers import Publisher
 from app.models.schemas.base import IWBaseSchema  # type: ignore
 
 
-class PublisherInResponse(IWBaseSchema):  # type: ignore
-    profile: Publisher
+class PublisherInCreate(IWBaseSchema):
+    name: Optional[str] = None
+    profile_picture: Optional[str] = None
+    banner: Optional[str] = None
+    bio: Optional[str] = None
+    address: Optional[str] = None
+    postal_code: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    office_phone_number: Optional[str] = None
+    mobile_phone_number: Optional[str] = None
 
 
 class PublisherInUpdate(pydantic.BaseModel):
@@ -16,3 +25,13 @@ class PublisherInUpdate(pydantic.BaseModel):
     profile_picture: Optional[str] = None
     banner: Optional[str] = None
     bio: Optional[str] = None
+    address: Optional[str] = None
+    postal_code: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    office_phone_number: Optional[str] = None
+    mobile_phone_number: Optional[str] = None
+
+
+class PublisherInResponse(IWBaseSchema):  # type: ignore
+    publisher: Publisher

--- a/backend/app/models/schemas/publishers.py
+++ b/backend/app/models/schemas/publishers.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+import pydantic
+
+from app.models.domain.publishers import Publisher
+from app.models.schemas.base import IWBaseSchema  # type: ignore
+
+
+class PublisherInResponse(IWBaseSchema):  # type: ignore
+    profile: Publisher
+
+
+class PublisherInUpdate(pydantic.BaseModel):
+
+    name: Optional[str] = None
+    profile_picture: Optional[str] = None
+    banner: Optional[str] = None
+    bio: Optional[str] = None

--- a/backend/app/resources/http_exc_details.py
+++ b/backend/app/resources/http_exc_details.py
@@ -7,7 +7,7 @@ def http_400_details(username: str = None, email: str = None) -> str:
     return "Login failed! Re-check heck your email and password!"
 
 
-HTTP_300_DETAILS = "Unable to validate credentials; Check the JWT token or login credentials!"
+HTTP_403_DETAILS = "Unable to validate credentials; Check the JWT token or login credentials!"
 
 
 def http_404_details(id: int = None, username: str = None) -> str:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,7 +9,11 @@ from asyncpg import pool as asyncpg_pool
 
 from app.core.config import get_settings
 from app.core.settings.base import EnvTypes
+from app.db.repositories.journalists import JournalistsRepository
+from app.db.repositories.publishers import PublishersRepository
 from app.db.repositories.users import UsersRepository
+from app.models.domain.journalists import Journalist
+from app.models.domain.publishers import Publisher
 from app.models.domain.users import UserInDB
 from app.services.jwt import generate_access_token
 from tests.fake_asyncpg_pool import FakeAsyncPGPool
@@ -80,6 +84,80 @@ async def test_user(test_pool: asyncpg_pool.Pool) -> UserInDB:
             email="user.test@test.com",
             password="password-test",
             is_publisher=False,
+        )
+
+
+@pytest.fixture(name="test_user_journalist")
+async def test_user_journalist(test_pool: asyncpg_pool.Pool) -> UserInDB:
+    async with test_pool.acquire() as conn:
+        return await UsersRepository(conn).create_user(
+            username="usertest2",
+            email="user2.test2@test.com",
+            password="password2-test2",
+            is_publisher=False,
+        )
+
+
+@pytest.fixture(name="test_user_publisher")
+async def test_user_publisher(test_pool: asyncpg_pool.Pool) -> UserInDB:
+    async with test_pool.acquire() as conn:
+        return await UsersRepository(conn).create_user(
+            username="usertest3",
+            email="user3.test3@test.com",
+            password="password3-test3",
+            is_publisher=True,
+        )
+
+
+@pytest.fixture(name="test_user_publisher_2")
+async def test_user_publisher_2(test_pool: asyncpg_pool.Pool) -> UserInDB:
+    async with test_pool.acquire() as conn:
+        return await UsersRepository(conn).create_user(
+            username="usertest4",
+            email="user4.test4@test.com",
+            password="password4-test4",
+            is_publisher=True,
+        )
+
+
+@pytest.fixture(name="test_journalist")
+async def test_journalist(
+    test_user: UserInDB,
+    test_pool: asyncpg_pool.Pool) -> Journalist:
+    async with test_pool.acquire() as conn:
+        return await JournalistsRepository(conn).create_journalist_by_username(
+            username=test_user.username,
+            first_name="Tester",
+            last_name="Journalist",
+            profile_picture="home/test/pp/journalist.png",
+            banner="home/test/banner/journalist_banner.png",
+            bio="Awesome super journalist",
+            address="Secretstreet 666",
+            postal_code="13055",
+            state="Kuta",
+            country="Dreamland",
+            office_phone_number="+666",
+            mobile_phone_number="+666911",
+        )
+
+
+@pytest.fixture(name="test_publisher")
+async def test_publisher(
+    test_user_publisher: UserInDB,
+    test_pool: asyncpg_pool.Pool) -> Publisher:
+    async with test_pool.acquire() as conn:
+        return await PublishersRepository(conn).create_publisher_by_username(
+            username=test_user_publisher.username,
+            name="AxelSpringer",
+            profile_picture="home/test/pp/AxelSpringer.png",
+            banner="home/test/banner/AxelSPringerBanner.png",
+            bio="Biggest media house in Europe!",
+            address="Zimmermannstr. 50",
+            postal_code="14350",
+            state="Mitte",
+            country="Germany",
+            office_phone_number="+6661234567",
+            mobile_phone_number="+66691112314",
         )
 
 

--- a/backend/tests/integration_tests/test_api/test_routes/test_journalists.py
+++ b/backend/tests/integration_tests/test_api/test_routes/test_journalists.py
@@ -1,0 +1,121 @@
+# type: ignore
+import fastapi
+import httpx
+
+from app.models.domain.journalists import JournalistInDB
+from app.models.domain.users import UserInDB
+
+
+async def test_get_all_journalists_successful(
+    test_user_publisher_2: UserInDB,
+    authorized_async_client: httpx.AsyncClient,
+) -> None:
+
+    new_publisher = {
+        "journalist": {
+            "first_name": "John",
+            "last_name": "Doe",
+            "profile_picture": "home/holiday/holiday_in_dubai_2020.png",
+            "banner": "",
+            "bio": "",
+            "address": "",
+            "postal_code": "",
+            "state": "",
+            "country": "",
+            "office_phone_number": "+493012335",
+            "mobile_phone_number": "+4912516372932",
+            "user_id": test_user_publisher_2.id_,
+        }
+    }
+
+    response = await authorized_async_client.post(url="api/journalists", json=new_publisher)
+    assert response.status_code == fastapi.status.HTTP_201_CREATED
+
+    response = await authorized_async_client.get(url="api/journalists")
+
+    assert response.status_code == fastapi.status.HTTP_200_OK
+
+    assert response.json() == [
+        {
+            "journalist": {
+                "firstName": "John",
+                "lastName": "Doe",
+                "profilePicture": "home/holiday/holiday_in_dubai_2020.png",
+                "banner": "",
+                "bio": "",
+                "address": "",
+                "postalCode": "",
+                "state": "",
+                "country": "",
+                "officePhoneNumber": "+493012335",
+                "mobilePhoneNumber": "+4912516372932",
+                "userId": 2,
+            }
+        },
+    ]
+
+
+async def test_retrieve_current_journalist_successful(
+    authorized_async_client: httpx.AsyncClient,
+    test_journalist: JournalistInDB,
+    test_user: UserInDB,
+) -> None:
+
+    response = await authorized_async_client.get(url=f"api/journalists/journalist/{test_user.username}")
+    assert response.status_code == fastapi.status.HTTP_200_OK
+    assert response.json() == {
+        "journalist": {
+            "firstName": "Tester",
+            "lastName": "Journalist",
+            "profilePicture": "home/test/pp/journalist.png",
+            "banner": "home/test/banner/journalist_banner.png",
+            "bio": "Awesome super journalist",
+            "address": "Secretstreet 666",
+            "postalCode": "13055",
+            "state": "Kuta",
+            "country": "Dreamland",
+            "officePhoneNumber": "+666",
+            "mobilePhoneNumber": "+666911",
+            "userId": test_user.id_,
+        }
+    }
+
+
+async def test_update_current_journalist_successful(
+    test_user: UserInDB,
+    test_journalist: JournalistInDB,
+    authorized_async_client: httpx.AsyncClient,
+) -> None:
+
+    updated_journalist_data = {
+        "journalist": {
+            "first_name": "John Doe",
+            "last_name": "Doe",
+            "banner": None,
+            "bio": "Updated awesome journalist!",
+            "profile_picture": "home/holiday/holiday_in_dubai_2020.png",
+            "office_phone_number": "+493012335",
+            "mobile_phone_number": "+4912516372932",
+        }
+    }
+
+    response = await authorized_async_client.put(
+        url=f"api/journalists/journalist/{test_user.username}", json=updated_journalist_data
+    )
+    assert response.status_code == fastapi.status.HTTP_200_OK
+    assert response.json() == {
+        "journalist": {
+            "firstName": "John Doe",
+            "lastName": "Doe",
+            "profilePicture": "home/holiday/holiday_in_dubai_2020.png",
+            "banner": None,
+            "bio": "Updated awesome journalist!",
+            "address": test_journalist.address,
+            "postalCode": test_journalist.postal_code,
+            "state": test_journalist.state,
+            "country": test_journalist.country,
+            "officePhoneNumber": "+493012335",
+            "mobilePhoneNumber": "+4912516372932",
+            "userId": test_user.id_,
+        }
+    }

--- a/backend/tests/integration_tests/test_api/test_routes/test_publishers.py
+++ b/backend/tests/integration_tests/test_api/test_routes/test_publishers.py
@@ -1,0 +1,42 @@
+# type: ignore
+import fastapi
+import httpx
+
+from app.models.domain.publishers import Publisher
+from app.models.domain.users import UserInDB
+
+
+async def test_get_all_publishers_successful(
+    test_publisher: Publisher,
+    authorized_async_client: httpx.AsyncClient,
+) -> None:
+
+    response = await authorized_async_client.get(url="api/publishers")
+
+    assert response.status_code == fastapi.status.HTTP_200_OK
+    assert response.json() == [
+        {
+            "publisher": {
+                "name": "AxelSpringer",
+                "profilePicture": "home/test/pp/AxelSpringer.png",
+                "banner": "home/test/banner/AxelSPringerBanner.png",
+                "bio": "Biggest media house in Europe!",
+                "address": "Zimmermannstr. 50",
+                "postalCode": "14350",
+                "state": "Mitte",
+                "country": "Germany",
+                "officePhoneNumber": "+6661234567",
+                "mobilePhoneNumber": "+66691112314",
+                "userId": 1,
+            }
+        },
+    ]
+
+
+async def test_fail_to_retrieve_current_publisher_because_not_authorized(
+    async_client: httpx.AsyncClient,
+    test_user_publisher_2: UserInDB,
+) -> None:
+
+    response = await async_client.get(url=f"api/publishers/publisher/{test_user_publisher_2.username}")
+    assert response.status_code == fastapi.status.HTTP_403_FORBIDDEN

--- a/backend/tests/integration_tests/test_api/test_routes/test_users.py
+++ b/backend/tests/integration_tests/test_api/test_routes/test_users.py
@@ -6,6 +6,7 @@ from asyncpg import pool as asyncpg_pool
 from app.db.repositories.users import UsersRepository
 from app.models.domain.users import UserInDB
 from app.models.schemas.users import UserInResponse
+from app.resources.http_exc_details import http_404_details
 
 
 async def test_get_all_users_successful(
@@ -65,8 +66,8 @@ async def test_retrieve_current_user_successful(
     response = await authorized_async_client.get(url="api/users/user/1")
     assert response.status_code == fastapi.status.HTTP_200_OK
 
-    user_profile = UserInResponse(**response.json())
-    assert user_profile.user.email == test_user.email
+    db_user = UserInResponse(**response.json())
+    assert db_user.user.email == test_user.email
 
 
 async def test_fail_to_retrieve_current_user_by_invalid_id_not_found(
@@ -75,9 +76,7 @@ async def test_fail_to_retrieve_current_user_by_invalid_id_not_found(
 
     response = await authorized_async_client.get(url="api/users/user/2")
     assert response.status_code == fastapi.status.HTTP_404_NOT_FOUND
-    assert response.json() == {
-        "errors": ["Either the user with ID 2 is deleted, or you are not authorized; Check your authorization!"]
-    }
+    assert response.json() == {"errors": [http_404_details(id=2)]}
 
 
 async def test_update_current_user_username_and_email_successful(

--- a/backend/tests/tables.py
+++ b/backend/tests/tables.py
@@ -1,8 +1,8 @@
 create_db_tables = """
     CREATE TABLE IF NOT EXISTS users (
-        id SERIAL PRIMARY KEY,
-        username VARCHAR(50),
-        email VARCHAR(50),
+        id SERIAL PRIMARY KEY NOT NULL,
+        username VARCHAR(50) NOT NULL,
+        email VARCHAR(50) NOT NULL,
         salt VARCHAR,
         hashed_password VARCHAR,
         is_publisher BOOL,
@@ -10,8 +10,45 @@ create_db_tables = """
         is_active BOOL,
         created_at TIMESTAMP,
         updated_at TIMESTAMP);
+
+    CREATE TABLE IF NOT EXISTS journalists (
+        id SERIAL PRIMARY KEY NOT NULL,
+        first_name VARCHAR,
+        last_name VARCHAR,
+        bio VARCHAR,
+        profile_picture VARCHAR,
+        banner VARCHAR,
+        address VARCHAR,
+        postal_code VARCHAR,
+        state VARCHAR,
+        country VARCHAR,
+        office_phone_number VARCHAR,
+        mobile_phone_number VARCHAR,
+        user_id INTEGER,
+        FOREIGN KEY ("user_id") REFERENCES users("id"),
+        created_at TIMESTAMP,
+        updated_at TIMESTAMP);
+
+    CREATE TABLE IF NOT EXISTS publishers (
+        id SERIAL PRIMARY KEY NOT NULL,
+        name VARCHAR,
+        bio VARCHAR,
+        profile_picture VARCHAR,
+        banner VARCHAR,
+        address VARCHAR,
+        postal_code VARCHAR,
+        state VARCHAR,
+        country VARCHAR,
+        office_phone_number VARCHAR,
+        mobile_phone_number VARCHAR,
+        user_id INTEGER,
+        FOREIGN KEY ("user_id") REFERENCES users("id"),
+        created_at TIMESTAMP,
+        updated_at TIMESTAMP);
 """
 
 drop_db_tables = """
+    DROP TABLE IF EXISTS journalists;
+    DROP TABLE IF EXISTS publishers;
     DROP TABLE IF EXISTS users;
 """

--- a/backend/tests/unit_tests/test_repositores/test_journalists.py
+++ b/backend/tests/unit_tests/test_repositores/test_journalists.py
@@ -1,0 +1,214 @@
+from asyncpg import pool as asyncpg_pool
+
+from app.db.repositories.journalists import JournalistsRepository
+from app.models.domain.journalists import Journalist
+from app.models.domain.users import UserInDB
+from app.models.schemas.journalists import JournalistInResponse
+
+
+async def test_create_journalist_with_default_create_parameter(
+    test_user: UserInDB, test_pool: asyncpg_pool.Pool
+) -> None:
+
+    expected_data = {
+        "journalist": {
+            "first_name": "John",
+            "last_name": "Doe",
+            "profile_picture": "",
+            "banner": "",
+            "bio": "",
+            "address": "",
+            "postal_code": "",
+            "state": "",
+            "country": "",
+            "office_phone_number": "",
+            "mobile_phone_number": "",
+            "user_id": 1,
+        }
+    }
+
+    async with test_pool.acquire() as conn:
+        journalists_repo = await JournalistsRepository(conn).create_journalist_by_username(
+            username=test_user.username,
+            first_name="John",
+            last_name="Doe",
+        )
+
+    new_journalist = JournalistInResponse(
+        journalist=Journalist(
+            first_name=journalists_repo.first_name,
+            last_name=journalists_repo.last_name,
+            profile_picture=journalists_repo.profile_picture,
+            banner=journalists_repo.banner,
+            bio=journalists_repo.bio,
+            address=journalists_repo.address,
+            postal_code=journalists_repo.postal_code,
+            state=journalists_repo.state,
+            country=journalists_repo.country,
+            office_phone_number=journalists_repo.office_phone_number,
+            mobile_phone_number=journalists_repo.mobile_phone_number,
+            user_id=test_user.id_,
+        )
+    )
+
+    assert new_journalist.dict() == expected_data
+
+
+async def test_read_all_journalists(
+    test_user: UserInDB, test_user_journalist: UserInDB, test_pool: asyncpg_pool.Pool
+) -> None:
+
+    expected_data = [
+        {
+            "id_": 1,
+            "first_name": "John",
+            "last_name": "Doe",
+            "profile_picture": "",
+            "banner": "",
+            "bio": "Awesome test!",
+            "address": "Pytest 911",
+            "postal_code": "10203",
+            "state": "Berlin",
+            "country": "Germany",
+            "office_phone_number": "+493012335",
+            "mobile_phone_number": "+4912516372932",
+            "user_id": 1,
+        },
+        {
+            "id_": 2,
+            "first_name": "Maxi",
+            "last_name": "Musterfrau",
+            "profile_picture": "",
+            "banner": "",
+            "bio": "Not so awesome!",
+            "address": "Unittest 987",
+            "postal_code": "10407",
+            "state": "Dublin",
+            "country": "Ireland",
+            "office_phone_number": "",
+            "mobile_phone_number": "",
+            "user_id": 2,
+        },
+    ]
+
+    async with test_pool.acquire() as conn:
+        await JournalistsRepository(conn).create_journalist_by_username(
+            username=test_user.username,
+            first_name="John",
+            last_name="Doe",
+            profile_picture="",
+            banner="",
+            bio="Awesome test!",
+            address="Pytest 911",
+            postal_code="10203",
+            state="Berlin",
+            country="Germany",
+            office_phone_number="+493012335",
+            mobile_phone_number="+4912516372932",
+        )
+
+    async with test_pool.acquire() as conn:
+        await JournalistsRepository(conn).create_journalist_by_username(
+            username=test_user_journalist.username,
+            first_name="Maxi",
+            last_name="Musterfrau",
+            profile_picture="",
+            banner="",
+            bio="Not so awesome!",
+            address="Unittest 987",
+            postal_code="10407",
+            state="Dublin",
+            country="Ireland",
+            office_phone_number="",
+            mobile_phone_number="",
+        )
+
+    async with test_pool.acquire() as conn:
+        db_journalists = await JournalistsRepository(conn).get_journalists()
+
+    db_journalists[0].dict(exclude={"created_at", "updated_at"}) == expected_data[0]
+    db_journalists[1].dict(exclude={"created_at", "updated_at"}) == expected_data[1]
+
+
+async def test_read_journalist_by_user_id(test_user: UserInDB, test_pool: asyncpg_pool.Pool) -> None:
+
+    expected_data = {
+        "id_": 1,
+        "first_name": "John",
+        "last_name": "Doe",
+        "profile_picture": "",
+        "banner": "",
+        "bio": "Awesome test!",
+        "address": "Pytest 911",
+        "postal_code": "10203",
+        "state": "Berlin",
+        "country": "Germany",
+        "office_phone_number": "+493012335",
+        "mobile_phone_number": "+4912516372932",
+        "user_id": 1,
+    }
+
+    async with test_pool.acquire() as conn:
+        await JournalistsRepository(conn).create_journalist_by_username(
+            username=test_user.username,
+            first_name="John",
+            last_name="Doe",
+            profile_picture="",
+            banner="",
+            bio="Awesome test!",
+            address="Pytest 911",
+            postal_code="10203",
+            state="Berlin",
+            country="Germany",
+            office_phone_number="+493012335",
+            mobile_phone_number="+4912516372932",
+        )
+
+    async with test_pool.acquire() as conn:
+        db_journalist = await JournalistsRepository(conn).get_journalist_by_user_id(id=test_user.id)
+
+    assert db_journalist.dict(exclude={"created_at", "updated_at"}) == expected_data
+
+
+async def test_update_journalist_by_username(test_pool: asyncpg_pool.Pool, test_user: UserInDB) -> None:
+
+    expected_data = {
+        "id_": 1,
+        "first_name": "John",
+        "last_name": "Doe",
+        "profile_picture": "home/holiday/holiday_in_dubai_2020.png",
+        "banner": "",
+        "bio": "",
+        "address": "",
+        "postal_code": "",
+        "state": "",
+        "country": "",
+        "office_phone_number": "+493012335",
+        "mobile_phone_number": "+4912516372932",
+        "user_id": 1,
+    }
+
+    async with test_pool.acquire() as conn:
+        new_journalist = await JournalistsRepository(conn).create_journalist_by_username(
+            username=test_user.username,
+            first_name="John",
+            last_name="Doe",
+        )
+
+    async with test_pool.acquire() as conn:
+        updated_journalist = await JournalistsRepository(conn).update_journalist_by_user_id(
+            user_id=new_journalist.user_id,
+            first_name="John",
+            last_name="Doe",
+            profile_picture="home/holiday/holiday_in_dubai_2020.png",
+            banner="",
+            bio="",
+            address="",
+            postal_code="",
+            state="",
+            country="",
+            office_phone_number="+493012335",
+            mobile_phone_number="+4912516372932",
+        )
+
+    assert updated_journalist.dict(exclude={"created_at", "updated_at"}) == expected_data

--- a/backend/tests/unit_tests/test_repositores/test_publishers.py
+++ b/backend/tests/unit_tests/test_repositores/test_publishers.py
@@ -1,0 +1,199 @@
+from asyncpg import pool as asyncpg_pool
+
+from app.db.repositories.publishers import PublishersRepository
+from app.models.domain.publishers import Publisher
+from app.models.domain.users import UserInDB
+from app.models.schemas.publishers import PublisherInResponse
+
+
+async def test_create_publisher_with_default_create_parameter(
+    test_user_publisher: UserInDB, test_pool: asyncpg_pool.Pool
+) -> None:
+
+    expected_data = {
+        "publisher": {
+            "name": "Axel Springer",
+            "profile_picture": "",
+            "banner": "",
+            "bio": "",
+            "address": "",
+            "postal_code": "",
+            "state": "",
+            "country": "",
+            "office_phone_number": "",
+            "mobile_phone_number": "",
+            "user_id": test_user_publisher.id_,
+        }
+    }
+
+    async with test_pool.acquire() as conn:
+        publishers_repo = await PublishersRepository(conn).create_publisher_by_username(
+            username=test_user_publisher.username,
+            name="Axel Springer",
+        )
+
+    new_publisher = PublisherInResponse(
+        publisher=Publisher(
+            name=publishers_repo.name,
+            profile_picture=publishers_repo.profile_picture,
+            banner=publishers_repo.banner,
+            bio=publishers_repo.bio,
+            address=publishers_repo.address,
+            postal_code=publishers_repo.postal_code,
+            state=publishers_repo.state,
+            country=publishers_repo.country,
+            office_phone_number=publishers_repo.office_phone_number,
+            mobile_phone_number=publishers_repo.mobile_phone_number,
+            user_id=test_user_publisher.id_,
+        )
+    )
+
+    assert new_publisher.dict() == expected_data
+
+
+async def test_read_all_publishers(
+    test_user_publisher: UserInDB, test_user_publisher_2: UserInDB, test_pool: asyncpg_pool.Pool
+) -> None:
+
+    expected_data = [
+        {
+            "id_": 1,
+            "name": "Axel Springer",
+            "profile_picture": "",
+            "banner": "",
+            "bio": "Awesome test!",
+            "address": "Pytest 911",
+            "postal_code": "10203",
+            "state": "Berlin",
+            "country": "Germany",
+            "office_phone_number": "+493012335",
+            "mobile_phone_number": "+4912516372932",
+            "user_id": test_user_publisher.id_,
+        },
+        {
+            "id_": 2,
+            "name": "Spiegel",
+            "profile_picture": "",
+            "banner": "",
+            "bio": "Not so awesome!",
+            "address": "Unittest 987",
+            "postal_code": "10407",
+            "state": "Dublin",
+            "country": "Ireland",
+            "office_phone_number": "",
+            "mobile_phone_number": "",
+            "user_id": test_user_publisher_2.id_,
+        },
+    ]
+
+    async with test_pool.acquire() as conn:
+        await PublishersRepository(conn).create_publisher_by_username(
+            username=test_user_publisher.username,
+            name="Axel Springer",
+            profile_picture="",
+            banner="",
+            bio="Awesome test!",
+            address="Pytest 911",
+            postal_code="10203",
+            state="Berlin",
+            country="Germany",
+            office_phone_number="+493012335",
+            mobile_phone_number="+4912516372932",
+        )
+
+    async with test_pool.acquire() as conn:
+        await PublishersRepository(conn).create_publisher_by_username(
+            username=test_user_publisher_2.username,
+            name="Spiegel",
+            profile_picture="",
+            banner="",
+            bio="Not so awesome!",
+            address="Unittest 987",
+            postal_code="10407",
+            state="Dublin",
+            country="Ireland",
+            office_phone_number="",
+            mobile_phone_number="",
+        )
+
+    async with test_pool.acquire() as conn:
+        db_publishers = await PublishersRepository(conn).get_publishers()
+
+    db_publishers[0].dict(exclude={"created_at", "updated_at"}) == expected_data[0]
+    db_publishers[1].dict(exclude={"created_at", "updated_at"}) == expected_data[1]
+
+
+async def test_read_publisher_by_user_id(test_user_publisher: UserInDB, test_pool: asyncpg_pool.Pool) -> None:
+
+    expected_data = {
+        "id_": 1,
+        "name": "Axel Springer",
+        "profile_picture": "",
+        "banner": "",
+        "bio": "Awesome test!",
+        "address": "Pytest 911",
+        "postal_code": "10203",
+        "state": "Berlin",
+        "country": "Germany",
+        "office_phone_number": "+493012335",
+        "mobile_phone_number": "+4912516372932",
+        "user_id": test_user_publisher.id_,
+    }
+
+    async with test_pool.acquire() as conn:
+        await PublishersRepository(conn).create_publisher_by_username(
+            username=test_user_publisher.username,
+            name="Axel Springer",
+            profile_picture="",
+            banner="",
+            bio="Awesome test!",
+            address="Pytest 911",
+            postal_code="10203",
+            state="Berlin",
+            country="Germany",
+            office_phone_number="+493012335",
+            mobile_phone_number="+4912516372932",
+        )
+
+    async with test_pool.acquire() as conn:
+        db_publisher = await PublishersRepository(conn).get_publisher_by_user_id(id=test_user_publisher.id)
+
+    assert db_publisher.dict(exclude={"created_at", "updated_at"}) == expected_data
+
+
+async def test_update_publisher_by_username(test_pool: asyncpg_pool.Pool, test_user_publisher: UserInDB) -> None:
+
+    expected_data = {
+        "id_": 1,
+        "name": "Axel Springer",
+        "profile_picture": "home/holiday/holiday_in_dubai_2020.png",
+        "banner": "",
+        "bio": "",
+        "address": "",
+        "postal_code": "",
+        "state": "",
+        "country": "",
+        "office_phone_number": "+493012335",
+        "mobile_phone_number": "+4912516372932",
+        "user_id": test_user_publisher.id_,
+    }
+
+    async with test_pool.acquire() as conn:
+        await PublishersRepository(conn).create_publisher_by_username(
+            username=test_user_publisher.username,
+            name="Axel Springer",
+        )
+
+    async with test_pool.acquire() as conn:
+        db_publisher = await PublishersRepository(conn).get_publisher_by_user_id(id=test_user_publisher.id)
+
+    async with test_pool.acquire() as conn:
+        updated_publisher = await PublishersRepository(conn).update_publisher_by_user_id(
+            user_id=db_publisher.user_id,
+            name="Axel Springer",
+            profile_picture="home/holiday/holiday_in_dubai_2020.png",
+            office_phone_number="+493012335",
+            mobile_phone_number="+4912516372932",
+        )
+
+    assert updated_publisher.dict(exclude={"created_at", "updated_at"}) == expected_data

--- a/backend/tests/unit_tests/test_repositores/test_users.py
+++ b/backend/tests/unit_tests/test_repositores/test_users.py
@@ -6,7 +6,7 @@ from app.models.domain.users import UserInDB
 from app.models.schemas.users import UserInResponse, UserWithToken
 
 
-async def test_create_user_citizen_journalist_with_default_create_parameter(test_pool: asyncpg_pool.Pool) -> None:
+async def test_create_user_journalist_with_default_create_parameter(test_pool: asyncpg_pool.Pool) -> None:
 
     expected_data = {
         "user": {


### PR DESCRIPTION
-[X] Create some tests to refactor `JournalistsRepository` and journalists' routes,
-[X] Refactor `JournalistsRepository` by separating the get journalist method into 2:
    - [X] `create_journalist_from_user_by_username`,
    - [X] `get_journalists`,
    - [X] `get_journalist_by_user_id`,
    - [X] ùpdate_journalist_by_user_id`
- [X] Modify all journalists' routes,
- [X] Create tests for `PublishersRepository` and publishers' routes
- [X] Create domain and schema models for Publisher,
- [X] Create `PublishersRepository` and its SQL queries,
- [X] Create 4 routes and 1 dependency for `Publisher`:
    - [X] `create_publisher_for_suer_profile` to create publisher,
    - [X] `retreive_publishers`,
    - [X] `retreive_current_publisher` to utilize publisher's dependency `retrieve_current_publisher_auth` that return publisher iff user's is authorized,
    - [X] ùpdate_current_publsiher`,
- [X] Create some extra test users, test publishers, and test journalists,
- [X] Create SQL queries to create publishers and journalists tables for the test database.